### PR TITLE
Fixed backslash in path not recognized in Windows environment.

### DIFF
--- a/mp4concat.go
+++ b/mp4concat.go
@@ -127,10 +127,7 @@ func createInputFile(filesMP4 []string, inputFileNameAbsolute string) {
 	}
 	for _, v := range filesMP4 {
 		_, err := f.WriteString(
-			fmt.Sprintf(
-				"file %s\n",
-				strings.Replace(v, " ", "\\ ", -1),
-			),
+			fmt.Sprintf("file '%s'\n", v),
 		)
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
Changed path escaping to be done in single quotes.

Reference: https://ffmpeg.org/ffmpeg-utils.html#quoting_005fand_005fescaping