### PR TITLE
Change output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,23 @@ Files shot with GoPro are split into 4.01GB pieces.
 
 You can combine multiple files that have been split into one file without re-encoding (no video degradation).
 
-The ffmpeg command is required.
+## Requirements
 
-## How to use
+- [ffmpeg](https://ffmpeg.org/)
 
-Install ffmpeg beforehand.
+## Usage
 
-Double-click on mp4concat to start the terminal.
+Download and run the binary for the OS you are using from [Release](https://github.com/aoisupersix/mp4concat/releases).
 
 Display the contents of your GoPro's SD card in order of oldest to newest, and select all the video files you want to merge into one video. Only MP4 files will be used.
 
 Once you have pasted the list of files, activate the terminal (click on it) and hit the enter key. If you expand the window a little, you can see the status without scrolling.
 
+The combined file is output to the same directory as the input file.
+
 ## What's happening
 
-Create a file in the ~/Desktop/mp4concat_work folder with a list of the files passed to you (in the format used by ffmpeg's concat).
+Create a file with a list of files passed to a temporary folder (depending on the OS) and combine them with [ffmpeg's concat](https://trac.ffmpeg.org/wiki/Concatenate).
 
 ### Notice
 
@@ -27,9 +29,9 @@ If you need GPS metadata, please use official application.
 
 ## Platforms that are likely to work
 
-I tried to run it on macOS 11.1 (Big Sur).
+I tried to run it on Windows 11.
 
-go: 1.15
+Binaries for Linux and MacOSX are also generated, but have not been tested.
 
 ---
 
@@ -37,21 +39,23 @@ GoProで撮影したファイルは4.01GBごとに分割されてしまいます
 
 分割されてしまった複数ファイルを、再エンコードを行わずに1つのファイルに結合します（動画の劣化がありません）。
 
-ffmpegコマンドが必要です。
+## 要件
+
+- [ffmpeg](https://ffmpeg.org/)
 
 ## 使い方
 
-あらかじめffmpegをインストールしておきます。
-
-mp4concatをダブルクリックするとterminalが起動します。
+[リリース](https://github.com/aoisupersix/mp4concat/releases)から利用しているOS用のバイナリをダウンロードして実行します。
 
 GoProの撮影済みのSDカードの中身を日付の古い順に表示して、1つの動画に結合したい動画ファイルを全て選択します。このとき、THMファイルも一緒に選択してしまって構いません。MP4ファイルだけを利用します。
 
 ファイルの一覧を貼り付けられたら、terminalをアクティブにして（クリックして）、エンターキーを推します。ウィンドウを少し広げるとスクロールせずに状況が表示されます。
 
+結合後のファイルは入力されたファイルと同じディレクトリに出力します。
+
 ## 何が起きているのか
 
-~/Desktop/mp4concat_work フォルダに、渡されたファイルの一覧が記載されたファイルで作成します（ffmpegのconcatで使う形式で）。
+一時フォルダ(OSによって異なります)に渡されたファイルの一覧が記載されたファイルを作成し、[ffmpegのconcat](https://trac.ffmpeg.org/wiki/Concatenate)で結合します。
 
 ### 注意
 
@@ -60,6 +64,6 @@ GPS情報が必要な場合は、純正のアプリを使用してください�
 
 ## 動作すると思われるプラットフォーム
 
-macOSの11.1(Big Sur)で動作させてみました。
+Windows 11で動作確認してます。
 
-go: 1.15
+Linux、MacOSX用のバイナリも生成していますが、動作は未確認です。

--- a/mp4concat.go
+++ b/mp4concat.go
@@ -157,7 +157,7 @@ func main() {
 
 	// Create input file
 	mp4concatBasePath := basePath()
-	inputFileName := filepath.Join(mp4concatBasePath, fmt.Sprintf("%s.txt", uuid.New().String()))
+	inputFileName := filepath.Join(os.TempDir(), fmt.Sprintf("%s.txt", uuid.New().String()))
 	createInputFile(filesMP4, inputFileName)
 
 	// Build arguments for the ffmpeg command

--- a/mp4concat.go
+++ b/mp4concat.go
@@ -35,20 +35,6 @@ func splitFilePathBySpace(str string) []string {
 	return result
 }
 
-func basePath() string {
-	// mp4concat uses ~/Desktop/mp4concat , HARD CODED for now.
-	home, err := os.UserHomeDir()
-	if err != nil {
-		log.Print("Home directory not found")
-		log.Fatal(err)
-	}
-	dir := filepath.Join(home, "Desktop", "mp4concat_work")
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		os.Mkdir(dir, 0755)
-	}
-	return dir
-}
-
 func extractMP4Path(files []string) []string {
 	result := make([]string, 0, len(files))
 	for _, v := range files {
@@ -156,15 +142,16 @@ func main() {
 	}
 
 	// Create input file
-	mp4concatBasePath := basePath()
 	inputFileName := filepath.Join(os.TempDir(), fmt.Sprintf("%s.txt", uuid.New().String()))
 	createInputFile(filesMP4, inputFileName)
 
 	// Build arguments for the ffmpeg command
 	now := time.Now()
+	// output directory uses the first input file directory
+	outputDir := filepath.Dir(filesMP4[0])
 	outputFileName := fmt.Sprintf(
 		"%s/output_%04d%02d%02d_%02d%02d%02d.mp4",
-		mp4concatBasePath,
+		outputDir,
 		now.Year(),
 		now.Month(),
 		now.Day(),


### PR DESCRIPTION
- Change output destination of input files to temporary directory
  - To avoid leaving unnecessary garbage files after file merging
- Change the output destination of the combined file to the input file directory
  - I think it would be more convenient that way.
- Updated Readme.md